### PR TITLE
build: update xpkg organization to crossplane-contrib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ IMAGES = $(PROJECT_NAME)
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/jellysmack
+XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/jellysmack
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib
 XPKGS = $(PROJECT_NAME)
 -include build/makelib/xpkg.mk
 


### PR DESCRIPTION
### Description of your changes

This PR fixes the publishing error in main seen in https://github.com/crossplane-contrib/provider-upjet-mysql/actions/runs/11046971120/job/30687531656.
```
06:54:19 [ .. ] Pushing package xpkg.upbound.io/jellysmack/provider-upjet-mysql:v0.3.0-2.g00a212e
up: error: xpkg.pushCmd.Run(): GET https://xpkg.upbound.io/service/token?scope=repository%3Ajellysmack%2Fprovider-upjet-mysql%3Apush%2Cpull&service=xpkg.upbound.io: unexpected status code 404 Not Found
06:54:20 [FAIL]
```

Looks like #9 missed an update of the organization from `jellysmack` -> `crossplane-contrib`. I have searched the codebase and see no more hits for `jellysmack`, so this should be the last of it 😇 🙏 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
